### PR TITLE
Fix issue with yandex_maps.http.request

### DIFF
--- a/yandex_maps/api.py
+++ b/yandex_maps/api.py
@@ -10,7 +10,7 @@ from yandex_maps import http
 
 STATIC_MAPS_URL = 'http://static-maps.yandex.ru/1.x/?'
 HOSTED_MAPS_URL = 'http://maps.yandex.ru/?'
-GEOCODE_URL = 'http://geocode-maps.yandex.ru/1.x/?'
+GEOCODE_URL = 'https://geocode-maps.yandex.ru/1.x/?'
 
 def _format_point(longitude, latitude):
     return '%0.7f,%0.7f' % (float(longitude), float(latitude),)

--- a/yandex_maps/http.py
+++ b/yandex_maps/http.py
@@ -9,10 +9,10 @@ def request(method, url, data=None, headers={}, timeout=None):
     host_port = url.split('/')[2]
     timeout_set = False
     try:
-        connection = httplib.HTTPConnection(host_port, timeout = timeout)
+        connection = httplib.HTTPSConnection(host_port, timeout = timeout)
         timeout_set = True
     except TypeError:
-        connection = httplib.HTTPConnection(host_port)
+        connection = httplib.HTTPSConnection(host_port)
 
     with closing(connection):
         if not timeout_set:


### PR DESCRIPTION
Запрос к геокодеру представляет собой обращение по протоколу HTTPS к URL
https://geocode-maps.yandex.ru/1.x/.
